### PR TITLE
Update to be compatible with newest evil version

### DIFF
--- a/evil-traces.el
+++ b/evil-traces.el
@@ -40,10 +40,6 @@
 ;;   entry in `evil-traces--highlights' and make things more
 ;;   predictable for testing.  If clearing due to a suspension or
 ;;   stop, then just use `evil-traces--delete-hl'.
-;; - After calling a runner with 'start, `evil-ex-update' will
-;;   immediately call it with 'update, so there's no need to set
-;;   highlights in the 'start case like evil's :substitute runner
-;;   does.
 
 ;; * Setup
 (require 'cl-lib)
@@ -377,7 +373,7 @@ FLAG is the typical `evil-ex' argument runner flag.
 The highlight will be named HL-NAME and use HL-FACE.
 DEFAULT-RANGE may be either 'line or 'buffer."
   (cl-case flag
-    (update
+    ((start update)
      (with-current-buffer evil-ex-current-buffer
        (if-let ((range (or evil-ex-range
                            (cl-case default-range
@@ -449,7 +445,7 @@ RANGE-HL-NAME, RANGE-HL-FACE, PREVIEW-HL-NAME, PREVIEW-HL-FACE are the
 names and faces to use for the command's range and preview
 highlights."
   (cl-case flag
-    (update
+    ((start update)
      (with-current-buffer evil-ex-current-buffer
        (let* ((range (or evil-ex-range (evil-ex-range (evil-ex-current-line))))
               (beg (evil-range-beginning range))
@@ -506,9 +502,9 @@ highlights."
 FLAG is one of 'start, 'update, or 'stop and signals what to do.
 ARG is :global's ex argument."
   (cl-case flag
-    (start
-     (setq evil-traces--last-global-params nil))
-    (update
+    ((start update)
+     (when (eq flag 'start)
+       (setq evil-traces--last-global-params nil))
      (condition-case error-info
          (with-current-buffer evil-ex-current-buffer
            (let* ((range (or evil-ex-range (evil-ex-full-range)))
@@ -580,7 +576,7 @@ OUT-POSITIONS are positions outside the current ex range."
 FLAG is one of 'start, 'update, or 'stop and signals what to do.
 ARG is :join's ex argument."
   (cl-case flag
-    (update
+    ((start update)
      (with-current-buffer evil-ex-current-buffer
        (let* ((range (or evil-ex-range (evil-ex-range (evil-ex-current-line))))
               (beg (evil-range-beginning range))
@@ -620,7 +616,7 @@ FLAG is one of 'start, 'update, or 'stop and signals what to do, while ARG is
 :sort's ex argument.  If the variable `evil-ex-range' is nil, no preview is
 shown."
   (cl-case flag
-    (update
+    ((start update)
      (with-current-buffer evil-ex-current-buffer
        (cond
         ((and arg
@@ -665,9 +661,7 @@ shown."
 FLAG is one of 'start, 'update, or 'stop and signals what to do.
 ARG is :substitute's ex argument."
   (cl-case flag
-    (start
-     (evil-traces--evil-substitute-runner 'start arg))
-    (update
+    ((start update)
      (with-current-buffer evil-ex-current-buffer
        (let ((range (or evil-ex-range (evil-ex-range (evil-ex-current-line)))))
          (evil-traces--set-hl 'evil-traces-substitute-range
@@ -676,7 +670,7 @@ ARG is :substitute's ex argument."
                               'face
                               'evil-traces-substitute-range))
        (let ((evil-ex-hl-update-delay 0))
-         (evil-traces--evil-substitute-runner 'update arg))))
+         (evil-traces--evil-substitute-runner flag arg))))
     (stop
      (evil-traces--evil-substitute-runner 'stop arg)
      (evil-traces--delete-hl 'evil-traces-substitute-range))))

--- a/evil-traces.el
+++ b/evil-traces.el
@@ -263,13 +263,12 @@ RESUME-FORM will be executed every time a suspend ends."
 (defvar evil-traces--timer nil
   "The timer for evil-traces updates.")
 
-(defun evil-traces--run-with-ex-values (range cmd bang arg buffer fn &rest args)
+(defun evil-traces--run-with-ex-values (range bang arg buffer fn &rest args)
   "Run a function with certain `evil-ex' variables set to specified values.
 RANGE, CMD, BANG, ARG, and BUFFER will be the values of the
 corresponding `evil-ex' variables.  FN is the function to run, and
 ARGS is its argument list."
   (let ((evil-ex-range range)
-        (evil-ex-cmd cmd)
         (evil-ex-bang bang)
         (evil-ex-argument arg)
         (evil-ex-current-buffer buffer))
@@ -278,9 +277,8 @@ ARGS is its argument list."
 (defun evil-traces--run-timer (fn &rest args)
   "Use evil-traces' timer to run FN with ARGS.
 If the timer is currently running, then it is canceled first.  The
-variables `evil-ex-range', `evil-ex-cmd', `evil-ex-bang',
-`evil-ex-argument', and `evil-ex-current-buffer' will be preserved
-automatically."
+variables `evil-ex-range', `evil-ex-bang', `evil-ex-argument', and
+`evil-ex-current-buffer' will be preserved automatically."
   (when evil-traces--timer
     (cancel-timer evil-traces--timer))
   (setq evil-traces--timer
@@ -289,7 +287,6 @@ automatically."
                nil
                #'evil-traces--run-with-ex-values
                evil-ex-range
-               evil-ex-cmd
                evil-ex-bang
                evil-ex-argument
                evil-ex-current-buffer

--- a/evil-traces.el
+++ b/evil-traces.el
@@ -411,7 +411,8 @@ DEFAULT-RANGE may be either 'line or 'buffer."
 ;; ** Move / Copy
 (defun evil-traces--parse-move (arg)
   "Parse ARG into the position where :move will place its text."
-  (let ((parsed-arg (evil-ex-parse arg)))
+  ;; no idea why ``evil-ex-parse' might move the cursor on the first execution
+  (let ((parsed-arg (save-excursion (evil-ex-parse arg))))
     (when (eq (cl-first parsed-arg) 'evil-goto-line)
       (let* ((address (eval (cl-second parsed-arg))))
         (save-excursion

--- a/test/evil-traces-test.el
+++ b/test/evil-traces-test.el
@@ -80,7 +80,7 @@ This function returns `point-min' and `point-max' as the sole window range."
              ((symbol-function 'evil-traces--window-ranges) #'evil-traces--buffer-limits))
      ,@body))
 
-(evil-traces-mode)
+(evil-traces-mode 1)
 
 (ert-deftest evil-traces-test-simple ()
   "Test simple highlighting."
@@ -297,7 +297,7 @@ This function returns `point-min' and `point-max' as the sole window range."
             (evil-traces-join-out-indicators . ((12 12 after-string "  <<<")))))
          [return])
         (evil-traces--should-have-hls nil)
-        "no\nno\nno no[ ]no\nno\n")))
+        "no\nno\n[n]o no no\nno\n")))
   (ert-info ("Range and count given")
     (evil-traces--with-test-env
       (evil-test-buffer
@@ -309,7 +309,7 @@ This function returns `point-min' and `point-max' as the sole window range."
             (evil-traces-join-out-indicators . ((12 12 after-string "  <<<")))))
          [return])
         (evil-traces--should-have-hls nil)
-        "no\nno\nno no[ ]no\nno\n")))
+        "[n]o\nno\nno no no\nno\n")))
   (ert-info ("Suspend Highlighting")
     (evil-traces--with-test-env
       (let ((evil-traces-suspend-function #'evil-traces--no-range-and-arg-p))
@@ -329,7 +329,7 @@ This function returns `point-min' and `point-max' as the sole window range."
               (evil-traces-join-out-indicators . ((12 12 after-string "  <<<")))))
            [return])
           (evil-traces--should-have-hls nil)
-          "no\nno\nno no[ ]no\nno\n")))))
+          "[n]o\nno\nno no no\nno\n")))))
 
 (ert-deftest evil-traces-test-sort ()
   "Test highlighting :sort."


### PR DESCRIPTION
This package hasn't been updated in a while, and it needs a few small changes to work with the most recent `evil` version:

1. `evil-ex` no longer calls handlers with `'update` immediately after `'start`, so we need to generate overlays on the `'start` case.
2. `evil-ex-cmd` has been renamed to `evil--ex-cmd`. We don't really use this variable, so just remove any references to it.
3. `:move` and `:copy` might generate the wrong highlights right after starting up Emacs. `evil-ex-parse` moved the point for some reason, so wrap it in `save-excursion` for now.